### PR TITLE
use nodejs in-built support for es modules

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,4 @@
-import * as fs from 'fs-extra';
+import fs from 'fs-extra';;
 import ts from 'typescript';
 import * as rollup from 'rollup';
 
@@ -23,7 +23,8 @@ import * as rollup from 'rollup';
   if (result_es5.emitSkipped) {
     const diagnostic = result_es5.diagnostics[0];
     const error = new Error(diagnostic.messageText);
-    error.stack = error.stack.replace(/at .*/, 'at ' + diagnostic.file.fileName + ':' + diagnostic.file.lineMap.findIndex(value => value > diagnostic.start));
+    //error.stack = error.stack.replace(/at .*/, 'at ' + diagnostic.file.fileName + ':' + diagnostic.file.lineMap.findIndex(value => value > diagnostic.start));
+    console.error(diagnostic);
     throw error;
   }
   const result_es8 = program_es8.emit();
@@ -96,8 +97,8 @@ import * as rollup from 'rollup';
     },
   });
   await es8bundle.write({
-    file: 'asmcrypto.all.es8.js',
-    format: 'es',
+    file: 'asmcrypto.all.es8.cjs',
+    format: 'cjs',
   });
 
   console.log('Build complete');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/openpgpjs/asmcrypto.js",
   "main": "asmcrypto.all.js",
   "module": "asmcrypto.all.es8.js",
+  "type": "module",
   "browser": {
     "buffer": false,
     "crypto": false
@@ -36,7 +37,6 @@
     "@types/mocha": "^8.0.3",
     "@types/node": "^10.12.2",
     "chai": "^4.2.0",
-    "esm": "3.2.25",
     "fs-extra": "^9.0.1",
     "mocha": "^8.1.3",
     "prettier": "^1.14.3",
@@ -47,8 +47,8 @@
     "typescript": "^3.1.6"
   },
   "scripts": {
-    "prepare": "node -r esm build.js",
-    "test": "node -r esm build.js && mocha -r esm test/*.js",
+    "prepare": "node build.js",
+    "test": "node build.js && mocha test/*.js",
     "prettier": "prettier --single-quote --trailing-comma all --write \"src/**/*.js\" \"src/**/*.ts\" --print-width 120"
   },
   "typings": "./dist_es8/entry-export_all.d.ts",

--- a/src/aes/aes.ts
+++ b/src/aes/aes.ts
@@ -9,7 +9,7 @@ export class AES {
   public heap?: Uint8Array;
   public asm?: AES_asm;
   private readonly mode: string;
-  public padding: boolean; // TODO: This should be `private readonly`, hacking for AES-CFB?!
+  public padding?: boolean; // TODO: This should be `private readonly`, hacking for AES-CFB?!
   public pos: number = 0;
   public len: number = 0;
 

--- a/src/bignum/bignum.ts
+++ b/src/bignum/bignum.ts
@@ -10,17 +10,7 @@ export const _bigint_stdlib = { Uint32Array: Uint32Array, Math: Math };
 export const _bigint_heap = new Uint32Array(0x100000);
 export let _bigint_asm: bigintresult;
 
-function _half_imul(a: number, b: number) {
-  return (a * b) | 0;
-}
-
-if (_bigint_stdlib.Math.imul === undefined) {
-  _bigint_stdlib.Math.imul = _half_imul;
-  _bigint_asm = bigint_asm(_bigint_stdlib, null, _bigint_heap.buffer);
-  delete _bigint_stdlib.Math.imul;
-} else {
-  _bigint_asm = bigint_asm(_bigint_stdlib, null, _bigint_heap.buffer);
-}
+_bigint_asm = bigint_asm(_bigint_stdlib, null, _bigint_heap.buffer);
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/test/aes.js
+++ b/test/aes.js
@@ -1,4 +1,4 @@
-import * as asmCrypto from '../asmcrypto.all.es8';
+import * as asmCrypto from '../asmcrypto.all.es8.cjs';
 import chai from 'chai';
 const expect = chai.expect;
 

--- a/test/bignum.js
+++ b/test/bignum.js
@@ -1,4 +1,4 @@
-import * as asmCrypto from '../asmcrypto.all.es8';
+import * as asmCrypto from '../asmcrypto.all.es8.cjs';
 import chai from 'chai';
 const expect = chai.expect;
 

--- a/test/rsa.js
+++ b/test/rsa.js
@@ -1,4 +1,4 @@
-import * as asmCrypto from '../asmcrypto.all.es8';
+import * as asmCrypto from '../asmcrypto.all.es8.cjs';
 import chai from 'chai';
 const expect = chai.expect;
 

--- a/test/sha1.js
+++ b/test/sha1.js
@@ -1,4 +1,4 @@
-import * as asmCrypto from '../asmcrypto.all.es8';
+import * as asmCrypto from '../asmcrypto.all.es8.cjs';
 import chai from 'chai';
 const expect = chai.expect;
 

--- a/test/sha256.js
+++ b/test/sha256.js
@@ -1,4 +1,4 @@
-import * as asmCrypto from '../asmcrypto.all.es8';
+import * as asmCrypto from '../asmcrypto.all.es8.cjs';
 import chai from 'chai';
 const expect = chai.expect;
 

--- a/test/sha512.js
+++ b/test/sha512.js
@@ -1,4 +1,4 @@
-import * as asmCrypto from '../asmcrypto.all.es8';
+import * as asmCrypto from '../asmcrypto.all.es8.cjs';
 import chai from 'chai';
 const expect = chai.expect;
 


### PR DESCRIPTION
Hi there.
I've updated the package to use nodejs' in-built support for es modules. So no need for esm dependency.
Accepting this update I am proposing will help us in maintaining the package in Debian so we don't have to keep too many patches.
Thanks!